### PR TITLE
CB-39 Fix bug with IE11

### DIFF
--- a/src/cookie-control.css
+++ b/src/cookie-control.css
@@ -2,3 +2,7 @@
 #ccc .ccc-notify-button {
 	border-radius: 0 !important;
 }
+
+.ccc-notify-text {
+	width: 100%; /* To fix IE11 layout bug */
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,12 +10,15 @@ const ensureDataLayer = () => {
 	window.dataLayer = window.dataLayer || [];
 };
 
-export const loadCookieControl = async (): Promise<void> => {
+export const loadCookieControl = (): void => {
 	ensureDataLayer();
 
-	await loadjs("https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js", {
-		returnPromise: true,
+	loadjs(
+		"https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js",
+		"cookie-control"
+	);
+
+	loadjs.ready("cookie-control", function () {
+		window.CookieControl.load(cookieControlConfig);
 	});
-	console.log(cookieControlConfig);
-	window.CookieControl.load(cookieControlConfig);
 };


### PR DESCRIPTION
https://nicedigital.atlassian.net/browse/CB-39

We were using async version of loadjs which requires
global Promise which isn't supported in IE.

Chose to use non async version, rather than introducing a Promise polyfill.