### PR TITLE
CB-38 Use val loader to pre-load cookie control

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9206,9 +9206,9 @@
       }
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
     "node-int64": {
@@ -10828,12 +10828,12 @@
       "dev": true
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "dev": true,
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {
@@ -12247,6 +12247,49 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
           "dev": true
+        }
+      }
+    },
+    "val-loader": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/val-loader/-/val-loader-2.1.1.tgz",
+      "integrity": "sha512-0JKslgCSncZEGFuXAZp+caZMi15gjSC+WRUhrG0B6wPzLT7c0KfUzaOJHPYS49TrCbfUstXNQsw60FLUFqwmPw==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^2.6.5"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "schema-utils": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+          "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.5",
+            "ajv": "^6.12.4",
+            "ajv-keywords": "^3.5.2"
+          }
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1485,6 +1485,12 @@
         "pretty-format": "^25.2.1"
       }
     },
+    "@types/js-cookie": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.6.tgz",
+      "integrity": "sha512-+oY0FDTO2GYKEV0YPvSshGq9t7YozVkgvXLty7zogQNuCxBhT9/3INX9Q7H1aRZ4SUDRXAKlJuA4EA5nTt7SNw==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
@@ -8606,6 +8612,11 @@
           }
         }
       }
+    },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1485,22 +1485,10 @@
         "pretty-format": "^25.2.1"
       }
     },
-    "@types/js-cookie": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.6.tgz",
-      "integrity": "sha512-+oY0FDTO2GYKEV0YPvSshGq9t7YozVkgvXLty7zogQNuCxBhT9/3INX9Q7H1aRZ4SUDRXAKlJuA4EA5nTt7SNw==",
-      "dev": true
-    },
     "@types/json-schema": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
       "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
-      "dev": true
-    },
-    "@types/loadjs": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/loadjs/-/loadjs-4.0.0.tgz",
-      "integrity": "sha512-vg2B8Kw8U5d//cPuPoHX/kUiluMxbNyNTHzoRnetdW3HGEuFZJOorOWNRpn43bUJ2s2BCmMP79dtvl+irSJ3mg==",
       "dev": true
     },
     "@types/minimatch": {
@@ -8619,11 +8607,6 @@
         }
       }
     },
-    "js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8819,11 +8802,6 @@
         "emojis-list": "^3.0.0",
         "json5": "^1.0.1"
       }
-    },
-    "loadjs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/loadjs/-/loadjs-4.2.0.tgz",
-      "integrity": "sha512-AgQGZisAlTPbTEzrHPb6q+NYBMD+DP9uvGSIjSUM5uG+0jG15cb8axWpxuOIqrmQjn6scaaH8JwloiP27b2KXA=="
     },
     "locate-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,6 @@
   "devDependencies": {
     "@nice-digital/nds-core": "^1.0.23-alpha.0",
     "@types/jest": "^26.0.10",
-    "@types/js-cookie": "^2.2.6",
-    "@types/loadjs": "^4.0.0",
     "@typescript-eslint/eslint-plugin": "^3.9.1",
     "@typescript-eslint/parser": "^3.9.1",
     "clean-webpack-plugin": "^3.0.0",
@@ -69,6 +67,5 @@
     "webpack-dev-server": "^3.11.0",
     "webpack-merge": "^5.1.2"
   },
-  "dependencies": {
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -63,13 +63,12 @@
     "ts-jest": "^26.3.0",
     "ts-loader": "^8.0.2",
     "typescript": "^3.9.7",
+    "val-loader": "^2.1.1",
     "webpack": "^4.44.1",
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.0",
     "webpack-merge": "^5.1.2"
   },
   "dependencies": {
-    "js-cookie": "^2.2.1",
-    "loadjs": "^4.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@nice-digital/nds-core": "^1.0.23-alpha.0",
     "@types/jest": "^26.0.10",
+    "@types/js-cookie": "^2.2.6",
     "@typescript-eslint/eslint-plugin": "^3.9.1",
     "@typescript-eslint/parser": "^3.9.1",
     "clean-webpack-plugin": "^3.0.0",
@@ -67,5 +68,7 @@
     "webpack-dev-server": "^3.11.0",
     "webpack-merge": "^5.1.2"
   },
-  "dependencies": {}
+  "dependencies": {
+    "js-cookie": "^2.2.1"
+  }
 }

--- a/src/cookie-control-config.test.ts
+++ b/src/cookie-control-config.test.ts
@@ -1,14 +1,13 @@
 import { cookieControlConfig } from "./cookie-control-config";
-import { CookieControl } from "./types/cookie-control";
+import { CookieControl } from "./cookie-control";
 
 import { CookieControlPurpose } from "./types/cookie-control";
 
 describe("cookie-control-config", () => {
 	beforeEach(() => {
 		window.dataLayer = [];
-		window.CookieControl = {
-			getCategoryConsent: (index: number): boolean => index === 0,
-		} as CookieControl;
+
+		CookieControl.getCategoryConsent = (index: number): boolean => index === 0;
 	});
 
 	it("should match snapshot", () => {
@@ -36,7 +35,7 @@ describe("cookie-control-config", () => {
 	it("should push cookie.load dataLayer event on load", () => {
 		cookieControlConfig.onLoad && cookieControlConfig.onLoad();
 		expect(window.dataLayer).toHaveLength(1);
-		expect(window.dataLayer[0]).toEqual({
+		expect(window.dataLayer?.[0]).toEqual({
 			event: "cookie.load",
 			preferenceCookies: true,
 			analyticsCookies: false,
@@ -65,7 +64,7 @@ describe("cookie-control-config", () => {
 			}
 
 			expect(window.dataLayer).toHaveLength(1);
-			expect(window.dataLayer[0]).toEqual({
+			expect(window.dataLayer?.[0]).toEqual({
 				event: `cookie.${eventName}`,
 				[cookieType]: boolVal,
 			});
@@ -93,9 +92,7 @@ describe("cookie-control-config", () => {
 			}
 
 			expect(
-				window.CookieControl[
-					variableName as "preferenceCookies" | "analyticsCookies"
-				]
+				CookieControl[variableName as "preferenceCookies" | "analyticsCookies"]
 			).toEqual(boolVal);
 		}
 	);

--- a/src/cookie-control-config.ts
+++ b/src/cookie-control-config.ts
@@ -1,4 +1,5 @@
 import { CookieControlConfig } from "./types/cookie-control";
+import { CookieControl } from "./cookie-control";
 
 export const cookieControlConfig: CookieControlConfig = {
 	apiKey: "843970763414bd3ac1229c12767f5e7fab9ef68c",
@@ -9,13 +10,13 @@ export const cookieControlConfig: CookieControlConfig = {
 		let preferenceCookies = false;
 		let analyticsCookies = false;
 		try {
-			preferenceCookies = window.CookieControl.getCategoryConsent(0) || false;
-			analyticsCookies = window.CookieControl.getCategoryConsent(1) || false;
+			preferenceCookies = CookieControl.getCategoryConsent(0) || false;
+			analyticsCookies = CookieControl.getCategoryConsent(1) || false;
 		} catch {
 		} finally {
-			window.CookieControl.analyticsCookies = analyticsCookies;
-			window.CookieControl.preferenceCookies = preferenceCookies;
-			window.dataLayer.push({
+			CookieControl.analyticsCookies = analyticsCookies;
+			CookieControl.preferenceCookies = preferenceCookies;
+			window.dataLayer?.push({
 				event: "cookie.load",
 				preferenceCookies,
 				analyticsCookies,
@@ -72,15 +73,15 @@ export const cookieControlConfig: CookieControlConfig = {
 				"history-stack-details",
 			],
 			onAccept: function (): void {
-				window.CookieControl.preferenceCookies = true;
-				window.dataLayer.push({
+				CookieControl.preferenceCookies = true;
+				window.dataLayer?.push({
 					event: "cookie.preferences.accept",
 					preferenceCookies: true,
 				});
 			},
 			onRevoke: function (): void {
-				window.CookieControl.preferenceCookies = false;
-				window.dataLayer.push({
+				CookieControl.preferenceCookies = false;
+				window.dataLayer?.push({
 					event: "cookie.preferences.revoke",
 					preferenceCookies: false,
 				});
@@ -102,15 +103,15 @@ export const cookieControlConfig: CookieControlConfig = {
 				"_vis*",
 			],
 			onAccept: function (): void {
-				window.CookieControl.analyticsCookies = true;
-				window.dataLayer.push({
+				CookieControl.analyticsCookies = true;
+				window.dataLayer?.push({
 					event: "cookie.analytics.accept",
 					analyticsCookies: true,
 				});
 			},
 			onRevoke: function (): void {
-				window.CookieControl.analyticsCookies = false;
-				window.dataLayer.push({
+				CookieControl.analyticsCookies = false;
+				window.dataLayer?.push({
 					event: "cookie.analytics.revoke",
 					analyticsCookies: false,
 				});

--- a/src/cookie-control-config.ts
+++ b/src/cookie-control-config.ts
@@ -166,15 +166,15 @@ export const cookieControlConfig: CookieControlConfig = {
 				},
 			],
 			onAccept: function (): void {
-				window.CookieControl.marketingCookies = true;
-				window.dataLayer.push({
+				CookieControl.marketingCookies = true;
+				window.dataLayer?.push({
 					event: "cookie.marketing.accept",
 					marketingCookies: true,
 				});
 			},
 			onRevoke: function (): void {
-				window.CookieControl.marketingCookies = false;
-				window.dataLayer.push({
+				CookieControl.marketingCookies = false;
+				window.dataLayer?.push({
 					event: "cookie.marketing.revoke",
 					marketingCookies: false,
 				});

--- a/src/cookie-control.ts
+++ b/src/cookie-control.ts
@@ -1,0 +1,51 @@
+import https from "https";
+
+import { CookieControl as CookieControlType } from "./types/cookie-control";
+
+interface ValLoaderReturn {
+	cacheable: boolean;
+	code: string;
+}
+
+const CookieControlScriptUrl =
+	"https://cc.cdn.civiccomputing.com/9/cookieControl-9.3.1.min.js";
+
+// Loads the civic cookie control banner from the Civic CDN
+const getCivicCookieControl = async (): Promise<string> => {
+	return new Promise(async (resolve, reject) => {
+		const body: Uint8Array[] = [];
+		const req = await https.get(CookieControlScriptUrl, (res) => {
+			res.on("data", (chunk) => body.push(chunk));
+			res.on("end", () => {
+				const data = Buffer.concat(body).toString();
+				resolve(data);
+			});
+		});
+		req.on("error", (e) => {
+			reject(e);
+		});
+		req.end();
+	});
+};
+
+// Used by val-loader, at build time: val-loader looks for a default export
+// We do this for 2 reasons:
+//  a) improve load times by loading the Civic banner at build time
+//	b) not to rely on an external CDN at run time
+//  c) re-export the CookieControl object to allow 'proper' modules and not rely on a global reference defined on window
+export default async function (): Promise<ValLoaderReturn> {
+	const civicCookieControlScript = await getCivicCookieControl();
+
+	return {
+		cacheable: true,
+		code: `${civicCookieControlScript}\nmodule.exports = { CookieControl: window.CookieControl }`,
+	};
+}
+
+// Used purely for a type definition, hence the use of a placeholder, as the const needs to be initiated with something
+// This is replaced by val-loader at build time - see the default exported function above
+export const CookieControl: CookieControlType = ({
+	load: () => {
+		/* deliberately empty, used for mocking */
+	},
+} as unknown) as CookieControlType;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,83 +1,22 @@
 import { loadCookieControl } from "./index";
-import Cookie from "js-cookie";
-import loadjs from "loadjs";
-
 import { cookieControlConfig } from "./cookie-control-config";
-import { CookieControl } from "./types/cookie-control";
-
-jest.mock("js-cookie", () => ({
-	getJSON: jest.fn(),
-}));
-
-jest.mock("loadjs", () => {
-	const mock = jest.fn();
-	((mock as unknown) as typeof loadjs).ready = jest.fn();
-	return mock;
-});
+import { CookieControl } from "./cookie-control";
 
 describe("Load cookie control tests", () => {
 	beforeEach(() => {
-		window.CookieControl = (null as unknown) as CookieControl;
+		delete window.dataLayer;
 		jest.resetAllMocks();
 	});
 
-	it("should load cookie control plugin with config once script has loaded", () => {
-		const loadMock = jest.fn();
-		((loadjs.ready as unknown) as jest.Mock).mockImplementation(
-			(_name: string, callback: () => void) => {
-				window.CookieControl = ({
-					load: loadMock,
-				} as unknown) as CookieControl;
-				callback();
-			}
-		);
+	it("should load cookie control plugin with config", () => {
+		const loadMock = jest.spyOn(CookieControl, "load");
 		loadCookieControl();
 		expect(loadMock).toHaveBeenCalledWith(cookieControlConfig);
 	});
 
 	it("should ensure dataLayer exists", () => {
+		expect(window.dataLayer).toBeFalsy();
 		loadCookieControl();
-		expect(window.dataLayer).toBeTruthy;
-	});
-
-	it("should create placeholder CookieControl object from missing cookie", () => {
-		loadCookieControl();
-
-		expect(window.CookieControl).toStrictEqual({
-			analyticsCookies: false,
-			preferenceCookies: false,
-		});
-	});
-
-	it("should create placeholder CookieControl object from existing cookie with revoked consent", () => {
-		((Cookie.getJSON as unknown) as jest.Mock).mockImplementation(() => ({
-			optionalCookies: {
-				analytics: "revoked",
-				preferences: "revoked",
-			},
-		}));
-
-		loadCookieControl();
-
-		expect(window.CookieControl).toStrictEqual({
-			analyticsCookies: false,
-			preferenceCookies: false,
-		});
-	});
-
-	it("should create placeholder CookieControl object from existing cookie with consent", () => {
-		((Cookie.getJSON as unknown) as jest.Mock).mockImplementation(() => ({
-			optionalCookies: {
-				analytics: "accepted",
-				preferences: "accepted",
-			},
-		}));
-
-		loadCookieControl();
-
-		expect(window.CookieControl).toStrictEqual({
-			analyticsCookies: true,
-			preferenceCookies: true,
-		});
+		expect(window.dataLayer).toBeTruthy();
 	});
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,12 @@
+import Cookie from "js-cookie";
+
 import { loadCookieControl } from "./index";
 import { cookieControlConfig } from "./cookie-control-config";
 import { CookieControl } from "./cookie-control";
+
+jest.mock("js-cookie", () => ({
+	getJSON: jest.fn(),
+}));
 
 describe("Load cookie control tests", () => {
 	beforeEach(() => {
@@ -18,5 +24,51 @@ describe("Load cookie control tests", () => {
 		expect(window.dataLayer).toBeFalsy();
 		loadCookieControl();
 		expect(window.dataLayer).toBeTruthy();
+	});
+
+	it("should set CookieControl properties to false with missing cookie", () => {
+		loadCookieControl();
+
+		expect(CookieControl).toMatchObject({
+			analyticsCookies: false,
+			preferenceCookies: false,
+			marketingCookies: false,
+		});
+	});
+
+	it("should CookieControl object properties from existing cookie with revoked consent", () => {
+		((Cookie.getJSON as unknown) as jest.Mock).mockImplementation(() => ({
+			optionalCookies: {
+				analytics: "revoked",
+				preferences: "revoked",
+				marketing: "revoked",
+			},
+		}));
+
+		loadCookieControl();
+
+		expect(CookieControl).toMatchObject({
+			analyticsCookies: false,
+			preferenceCookies: false,
+			marketingCookies: false,
+		});
+	});
+
+	it("should CookieControl object properties from existing cookie with consent", () => {
+		((Cookie.getJSON as unknown) as jest.Mock).mockImplementation(() => ({
+			optionalCookies: {
+				analytics: "accepted",
+				preferences: "accepted",
+				marketing: "accepted",
+			},
+		}));
+
+		loadCookieControl();
+
+		expect(CookieControl).toMatchObject({
+			analyticsCookies: true,
+			preferenceCookies: true,
+			marketingCookies: true,
+		});
 	});
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,52 +1,11 @@
-import loadjs from "loadjs";
-import Cookies from "js-cookie";
+import { CookieControl } from "./cookie-control";
 
 import { cookieControlConfig } from "./cookie-control-config";
 import "./cookie-control.scss";
-import { CookieControl, CookieControlCookie } from "./types/cookie-control";
-
-export { CookieControlConfig } from "./types/cookie-control";
-export { cookieControlConfig } from "./cookie-control-config";
-
-const ensureDataLayer = () => {
-	window.dataLayer = window.dataLayer || [];
-};
-
-/**
- * Creates a placeholder Cookie Control object before the external library has loaded.
- *
- * It provides the public API for checking analytics and preference cookies, which
- * allows services to use CookieControl.preferenceCookies on page load.
- */
-const createPlaceholderCookieControl = () => {
-	const cookieControlCookie = Cookies.getJSON(
-		"CookieControl"
-	) as CookieControlCookie;
-
-	const analyticsCookies =
-			cookieControlCookie?.optionalCookies.analytics === "accepted",
-		preferenceCookies =
-			cookieControlCookie?.optionalCookies.preferences === "accepted";
-
-	window.CookieControl = window.CookieControl || ({} as CookieControl);
-
-	window.CookieControl.analyticsCookies = analyticsCookies;
-	window.CookieControl.preferenceCookies = preferenceCookies;
-};
 
 export const loadCookieControl = (): void => {
-	ensureDataLayer();
+	// Esnsure the GTM dataLayer array exists, in case the cookie banner is loaded before GTM
+	window.dataLayer = window.dataLayer || [];
 
-	createPlaceholderCookieControl();
-
-	loadjs(
-		"https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js",
-		"cookie-control"
-	);
-
-	loadjs.ready("cookie-control", () => {
-		// Re-add the custom properties after CookieControl is created
-		createPlaceholderCookieControl();
-		window.CookieControl.load(cookieControlConfig);
-	});
+	CookieControl.load(cookieControlConfig);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,39 @@
+import Cookies from "js-cookie";
 import { CookieControl } from "./cookie-control";
 
 import { cookieControlConfig } from "./cookie-control-config";
 import "./cookie-control.scss";
+import { CookieControlCookie } from "./types/cookie-control";
+
+// Ensure the GTM dataLayer array exists, in case the cookie banner is loaded before GTM
+const ensureDataLayer = () => {
+	window.dataLayer = window.dataLayer || [];
+};
+
+// Parse the cookie that gets set by Cookie Control ourselves.
+// This allows the properties like CookieControl.preferenceCookies to be available
+// even before the license has loaded asynchronously.
+const parseCookieControlCookie = () => {
+	const cookieControlCookie = Cookies.getJSON(
+		"CookieControl"
+	) as CookieControlCookie;
+
+	const analyticsCookies =
+			cookieControlCookie?.optionalCookies.analytics === "accepted",
+		preferenceCookies =
+			cookieControlCookie?.optionalCookies.preferences === "accepted",
+		marketingCookies =
+			cookieControlCookie?.optionalCookies.marketing === "accepted";
+
+	CookieControl.analyticsCookies = analyticsCookies;
+	CookieControl.preferenceCookies = preferenceCookies;
+	CookieControl.marketingCookies = marketingCookies;
+};
 
 export const loadCookieControl = (): void => {
-	// Ensure the GTM dataLayer array exists, in case the cookie banner is loaded before GTM
-	window.dataLayer = window.dataLayer || [];
+	ensureDataLayer();
+
+	parseCookieControlCookie();
 
 	CookieControl.load(cookieControlConfig);
 };

--- a/src/types/cookie-control.ts
+++ b/src/types/cookie-control.ts
@@ -145,14 +145,3 @@ export interface CookieControlConfig {
 		text?: CookieControlText;
 	}[];
 }
-
-/**
- * The type of the cookie object that the Cookie Control plugin stores
- */
-export interface CookieControlCookie {
-	optionalCookies: {
-		preferences?: "accepted" | "revoked";
-		analytics?: "accepted" | "revoked";
-	};
-	// There are other properties like necessaryCookies, consentDate etc but we don't need them...
-}

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -1,11 +1,7 @@
 export {};
 
-import { CookieControl } from "./cookie-control";
-
 declare global {
 	interface Window {
-		dataLayer: Record<string, unknown>[];
-
-		CookieControl: CookieControl;
+		dataLayer?: Record<string, unknown>[];
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "lib": ["es6", "DOM"],
     "module": "CommonJS",
     "rootDir": "src",
-    "outDir": "lib",
     "sourceMap": true,
     "strict": true,
     "strictNullChecks": true,
@@ -12,7 +11,7 @@
     "noImplicitAny": true,
     "forceConsistentCasingInFileNames": true,
     "allowJs": true,
-    "declaration": true
+    "declaration": false
   },
   "exclude": ["node_modules", "lib", "src/cdn.ts"],
   "include": ["src"]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,12 +15,29 @@ module.exports = {
 			},
 			{
 				test: /\.tsx?$/,
-				use: "ts-loader",
+				loader: "ts-loader",
 				exclude: /node_modules/,
+				options: {
+					transpileOnly: true,
+				},
 			},
 			{
 				test: /\.s[ac]ss$/i,
-				use: ["style-loader", "css-loader", "sass-loader"],
+				use: [
+					"style-loader",
+					{
+						loader: "css-loader",
+						options: {
+							sourceMap: process.env.NODE_ENV !== "production",
+						},
+					},
+					{
+						loader: "sass-loader",
+						options: {
+							sourceMap: process.env.NODE_ENV !== "production",
+						},
+					},
+				],
 			},
 		],
 	},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,10 @@ module.exports = {
 	module: {
 		rules: [
 			{
+				test: /cookie-control\.ts/,
+				use: "val-loader",
+			},
+			{
 				test: /\.tsx?$/,
 				use: "ts-loader",
 				exclude: /node_modules/,

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -11,6 +11,9 @@ module.exports = function (env) {
 
 		mode: "production",
 
+		// Our bundle is bigger than webpack's recommended size but that's OK - just ignore the message
+		performance: { hints: false },
+
 		plugins: [
 			new webpack.BannerPlugin({
 				banner: [


### PR DESCRIPTION
https://nicedigital.atlassian.net/browse/CB-38

Preload the Civic Cookie Control banner at build time, rather than at runtime.

We do this for 3 main reasons:

- improve load times by loading the Civic banner at build time
- not to rely on an external CDN at run time
- re-export the CookieControl object to allow 'proper' modules and not rely on a global reference defined on window.

And this has the nice side effect of not needing the custom cookie parsing code we had before, so we've removed that. This is a good thing - the cookie parsing was relying on an internal implementation detail of the Civic Cookie Banner.